### PR TITLE
Modifications to external PR to support custom CC VM names in CCW for Slurm

### DIFF
--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -289,9 +289,9 @@ var envNameToCloudMap = {
   AzureChinaCloud: 'AZURECHINACLOUD'
 }
 
-var acceptedChars_ClusterName = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z','A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z','0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '@', '-', '_']
+var acceptedChars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z','A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z','0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '@', '-', '_']
 var clusterNameArr = [for i in range(0, length(clusterName)): substring(clusterName, i, 1)]
-var clusterNameArrCleaned = [for c in clusterNameArr: contains(acceptedChars_ClusterName, c) ? c : '_']
+var clusterNameArrCleaned = [for c in clusterNameArr: contains(acceptedChars, c) ? c : '_']
 var clusterNameCleaned = join(clusterNameArrCleaned,'')
 
 output resourceGroup string = resourceGroup

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -289,9 +289,9 @@ var envNameToCloudMap = {
   AzureChinaCloud: 'AZURECHINACLOUD'
 }
 
-var acceptedChars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z','A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z','0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '@', '-', '_']
+var acceptedChars_ClusterName = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z','A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z','0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '@', '-', '_']
 var clusterNameArr = [for i in range(0, length(clusterName)): substring(clusterName, i, 1)]
-var clusterNameArrCleaned = [for c in clusterNameArr: contains(acceptedChars, c) ? c : '_']
+var clusterNameArrCleaned = [for c in clusterNameArr: contains(acceptedChars_ClusterName, c) ? c : '_']
 var clusterNameCleaned = join(clusterNameArrCleaned,'')
 
 output resourceGroup string = resourceGroup

--- a/bicep/mainTemplate.bicep
+++ b/bicep/mainTemplate.bicep
@@ -7,7 +7,7 @@ param adminUsername string
 param adminPassword string
 param adminSshPublicKey string = '' 
 param storedKey types.storedKey_t = {id: 'foo', location: 'foo', name:'foo'}
-@minLength(3)
+@minLength(1)
 @maxLength(64)
 param ccVMName string
 param ccVMSize string

--- a/bicep/mainTemplate.bicep
+++ b/bicep/mainTemplate.bicep
@@ -7,6 +7,8 @@ param adminUsername string
 param adminPassword string
 param adminSshPublicKey string = '' 
 param storedKey types.storedKey_t = {id: 'foo', location: 'foo', name:'foo'}
+@minLength(3)
+@maxLength(64)
 param ccVMName string
 param ccVMSize string
 param resourceGroup string

--- a/bicep/roleAssignmentCleanup.bicep
+++ b/bicep/roleAssignmentCleanup.bicep
@@ -2,7 +2,7 @@ targetScope = 'subscription'
 
 param location string
 param resourceGroup string
-param vmName string
+param vmName string = 'ccw-cyclecloud'
 param roles array = [
   'Contributor'
   'Storage Account Contributor'

--- a/bicep/vm.bicep
+++ b/bicep/vm.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 import * as types from './types.bicep'
 
 param name string
-param deployScript string
+param deployScript string 
 param osDiskSku string
 param image object //TODO: find a way to type this
 param location string
@@ -13,7 +13,7 @@ param adminUser string
 @secure()
 param adminPassword string
 @secure()
-param databaseAdminPassword string
+param databaseAdminPassword string 
 param adminSshPublicKey string
 param vmSize string
 param dataDisks array
@@ -93,10 +93,10 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
       {
         computerName: name
         adminUsername: adminUser
-      },
+      }, 
       deployScript != '' ? { // deploy script not empty
         customData: base64(deployScript)
-      } : {},
+      } : {}, 
       { // linux
         linuxConfiguration: {
           disablePasswordAuthentication: true
@@ -125,8 +125,10 @@ resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = {
     protectedSettings: {
       commandToExecute: 'jq -n --arg adminPassword "${adminPassword}" --arg databaseAdminPassword "${databaseAdminPassword}" \'{adminPassword: $adminPassword, databaseAdminPassword: $databaseAdminPassword}\' > /root/ccw.secrets.json'
     }
+    
   }
 }
+
 
 output fqdn string = '' //contains(vm, 'pip') && vm.pip ? publicIp.properties.dnsSettings.fqdn : ''
 output publicIp string = '' //contains(vm, 'pip') && vm.pip ? publicIp.properties.ipAddress : ''

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -82,8 +82,16 @@
         "toolTip": "Name for the CycleCloud VM",
         "constraints": {
           "required": true,
-          "regex": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}[a-zA-Z0-9_]$",
-          "validationMessage": "Enter a valid VM name"
+          "validations": [
+            {
+              "regex": "^[a-zA-Z0-9.-]{1,64}$",
+              "message": "Azure Linux VM names must be between 1 and 64 characters long and contain only letters, numbers, '.', and '-'."
+            },
+            {
+              "regex": "^(?![.-])(.*)(?<![.-])$",
+              "message": "Azure resource names may neither begin nor end with '.' or '-'."
+            }
+          ]
         },
         "visible": true
       },

--- a/util/delete_roles.sh
+++ b/util/delete_roles.sh
@@ -3,7 +3,6 @@ set -e
 
 DELETE_RG=0
 RG=""
-VM=""
 HELP=0
 
 while (( "$#" )); do
@@ -14,10 +13,6 @@ while (( "$#" )); do
             ;;
         -rg|--resource-group)
             RG=$2
-            shift 2
-            ;;
-        -vm|--virtual-machine)
-            VM=$2
             shift 2
             ;;
         --help)
@@ -43,13 +38,8 @@ if [ -z "$RG" ] ; then
     HELP=1
 fi
 
-if [ -z "$VM" ] ; then
-    echo "Please ensure that --virtual-machine is provided" >&2
-    HELP=1
-fi
-
 if [ $HELP == 1 ]; then
-    echo Usage: delete_roles.sh --resource-group RG --virtual-machine VM [--delete-resource-group] 1>&2
+    echo Usage: delete_roles.sh --resource-group RG [--delete-resource-group] 1>&2
     exit 1
 fi
 
@@ -73,9 +63,6 @@ cat > $CLEANUP_JSON_PATH<<EOF
         },
         "resourceGroup": {
             "value": "$RG"
-        },
-        "vmName": {
-            "value": "$VM"
         }
     }
 }


### PR DESCRIPTION
Hi @richardlock, 

We made a few modifications to your PR: 
- Updated the regex used to validate the CC VM name set in the UI
- Set minimum and maximum length of the ccVMName parameter in Bicep for manual deployments 
- Omitted changes to the role assignment-related files: we plan to make the role assignments independent of the VM name in the coming release, so we wish to keep the utility as-is for now 
- Omitted whitespace changes in vm.bicep: we will take care of this in a separate PR to keep this one focused